### PR TITLE
Add scraped page archive

### DIFF
--- a/scraper.rb
+++ b/scraper.rb
@@ -73,6 +73,9 @@ def scrape_list(url)
   data = page.members.map(&:to_h)
   # puts data
   ScraperWiki.save_sqlite(%i(id term), data)
+
+  # visit each 'source' page to archive it
+  data.each { |p| open(p[:source]).read }
 end
 
 scrape_list('http://www.tucamarapr.org/dnncamara/web/composiciondelacamara.aspx')

--- a/scraper.rb
+++ b/scraper.rb
@@ -6,8 +6,9 @@ require 'pry'
 require 'scraped'
 require 'scraperwiki'
 
-require 'open-uri/cached'
-OpenURI::Cache.cache_path = '.cache'
+# require 'open-uri/cached'
+# OpenURI::Cache.cache_path = '.cache'
+require 'scraped_page_archive/open-uri'
 
 class String
   def tidy


### PR DESCRIPTION
## What does this do?

Uses scraped-page-archive to archive all pages scraped. Archives existing scraped pages. Also opens individual member pages to archive without scraping.

## Why is this needed?

There's be an election (2016-11-08), and it's likely that the data on the official site will disappear, meaning any data we're not already picking up will be lost. Archiving it now gives us the chance to go back and re-scrape later even if it disappears.

## Relevant Issue(s):

https://github.com/everypolitician/everypolitician-data/issues/20544

## Checklists:

### Scraper change:
* [ ] scraper is on Morph.io under the "everypolitician-scrapers" group — no, it's still at https://morph.io/tmtmtmtm/puerto-rico-representantes, but there's little point in moving it this close to the election.
* [x] scraper's GitHub "Website" link points at morph.io page 
* [x] scraper is set to auto-run.
* [x] scraper is configured for archiving — that's what this PR is doing!

### Adding Archiving:
* [x] scraper uses scraped-page-archive gem directly or via a suitable strategy — uses it directly
* [ ] MORPH_SCRAPER_CACHE_GITHUB_REPO_URL is configured — not yet. @tmtmtmtm this needs configured on morph
* [x] pages are being archived in new branch of correct scraper repo (yay!)

### Gemfile change:
* [x] all links are secure
* [x] links to Github use `github:` protocol, not simply `git:`
* [x] formatting is consistent with our normal Rubocop setup