### PR TITLE
Set up framework for custom tests

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -5,6 +5,10 @@ require 'rake/testtask'
 
 RuboCop::RakeTask.new
 
+Rake::TestTask.new do |t|
+  t.test_files = FileList['test/**/*_test.rb']
+end
+
 require 'scraper_test'
 ScraperTest::RakeTask.new.install_tasks
 

--- a/test/dummy_test.rb
+++ b/test/dummy_test.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+require_relative './test_helper'
+
+describe 'dummy test' do
+  it 'should run' do
+    # This test is included to ensure that
+    # test_helper is run by Travis
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require 'minitest/around/spec'
+require 'minitest/autorun'
+require 'pry'
+require 'vcr'
+require 'webmock'
+
+VCR.configure do |c|
+  c.cassette_library_dir = 'test/cassettes'
+  c.hook_into :webmock
+end


### PR DESCRIPTION
This PR is being made in preparation of (https://github.com/everypolitician-scrapers/puerto-rico-representantes/pull/5)

To test an individual row, the tests need to run against a subset of the data returned by `MembersPage`. `scraper_test` cannot currently target subsets of data (https://github.com/everypolitician/scraper_test/issues/13) and so a custom test is required.