### PR TITLE
WIP: Site layout changes

### DIFF
--- a/lib/member_div.rb
+++ b/lib/member_div.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require 'scraped'
+
+class MemberDiv < Scraped::HTML
+  field :id do
+    source.split('=').last
+  end
+
+  field :name do
+    bio.first.sub('Hon. ', '')
+  end
+
+  field :area do
+    bio.last.split(/del|por/).last.tidy
+  end
+
+  field :image do
+    noko.at_css('img @src').text
+  end
+
+  field :source do
+    noko.at_css('a @href').text
+  end
+
+  private
+
+  def bio
+    noko.at_css('.biodiv').text.split("\n").map(&:tidy).reject(&:empty?)
+  end
+end

--- a/lib/member_page.rb
+++ b/lib/member_page.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require 'scraped'
+
+class MemberPage < Scraped::HTML
+  field :party do
+    noko.at_css('.partyBio').text.tidy
+  end
+
+  field :phone do
+    contact_numbers_for('Tel')
+  end
+
+  field :fax do
+    contact_numbers_for('Fax')
+  end
+
+  field :tty do
+    contact_numbers_for('TTY')
+  end
+
+  private
+
+  def contact_numbers
+    noko.xpath('.//span[@class="data-type"]')
+  end
+
+  def contact_numbers_for(str)
+    contact_numbers.xpath("text()[contains(.,'#{str}')]").map do |n|
+      n.text.gsub("#{str}.", '').tidy
+    end.reject(&:empty?).join(';')
+  end
+end

--- a/scraper.rb
+++ b/scraper.rb
@@ -58,7 +58,7 @@ class MembersPage < Scraped::HTML
   end
 end
 
-start = 'http://www.tucamarapr.org/dnncamara/web/composiciondelacamara.aspx'
+start = 'http://www.tucamarapr.org/dnncamara/web/ComposiciondelaCamara/Biografia.aspx'
 page = MembersPage.new(response: Scraped::Request.new(url: start).response)
 data = page.members.map(&:to_h)
 data.each { |mem| puts mem.reject { |_, v| v.to_s.empty? }.sort_by { |k, _| k }.to_h } if ENV['MORPH_DEBUG']

--- a/scraper.rb
+++ b/scraper.rb
@@ -52,7 +52,7 @@ class MembersPage < Scraped::HTML
   decorator Scraped::Response::Decorator::CleanUrls
 
   field :members do
-    noko.css('div.info-block div.info-wrap').map do |div|
+    noko.css('.list-article .selectionRep').map do |div|
       fragment div => MemberDiv
     end
   end

--- a/scraper.rb
+++ b/scraper.rb
@@ -10,43 +10,8 @@ require 'scraperwiki'
 # OpenURI::Cache.cache_path = '.cache'
 require 'scraped_page_archive/open-uri'
 
-class MemberDiv < Scraped::HTML
-  field :id do
-    noko.css('a.more-info/@href').text[/rep=(\d+)/, 1]
-  end
+require_rel 'lib'
 
-  field :name do
-    noko.xpath('.//span[@class="info"]//span[@class="name"]/text()').text.split(' - ').first.tidy.sub('Hon. ', '')
-  end
-
-  field :party do
-    noko.css('.info .party').text.tidy
-  end
-
-  field :area do
-    noko.css('.info .district').text.tidy
-  end
-
-  field :image do
-    noko.css('.identity img/@src').text
-  end
-
-  field :phone do
-    noko.xpath('.//span[@class="data-type" and contains(.,"Tel:")]').map { |n| n.text.sub('Tel:', '').tidy }.reject(&:empty?).join(' / ')
-  end
-
-  field :fax do
-    noko.xpath('.//span[@class="data-type" and contains(.,"Fax:")]').map { |n| n.text.sub('Fax:', '').tidy }.reject(&:empty?).join(' / ')
-  end
-
-  field :contact_form do
-    noko.css('a.mail/@href').text
-  end
-
-  field :source do
-    noko.css('a.more-info/@href').text
-  end
-end
 
 class MembersPage < Scraped::HTML
   decorator Scraped::Response::Decorator::CleanUrls


### PR DESCRIPTION
The site layout has changed and the scraper no longer pulls in data. This PR updates CSS selectors in MembersPage and MemberDiv and also adds MemberPage.

Note:
The scraper was capturing contact form urls for members (e.g. http://www.tucamarapr.org/dnncamara/web/contacto.aspx?rep=35). The forms are still live but I cannot find a link to them in either the member rows or member pages. As such, I have dropped this field.

In addition to voice phone and fax, member pages also list a TTY number. (I've opened a PR in csv_to_popolo to handle TTY numbers: tmtmtmtm/csv_to_popolo#115)